### PR TITLE
Add function to parse and add dictionary to etcd

### DIFF
--- a/observing/parsesdf.py
+++ b/observing/parsesdf.py
@@ -394,7 +394,7 @@ def volt_beam_obs(obs_list, session, mode='buffer'):
             beam_gain = 6
             logger.warning(f"OBS_DRX_GAIN is not defined, using a value of {beam_gain}")
             
-        cmd = f"con.start_dr(recorders=['drt'+str({session.beam_num})], duration = {obs.obs_dur}, time_avg=0, t0={t0}, teng_f1={obs.freq1}, teng_f2={obs.freq2}, f0={obs.bw}, gain={beam_gain})"
+        cmd = f"con.start_dr(recorders=['drt'+str({session.beam_num})], duration = {obs.obs_dur}, time_avg=0, t0={t0}, teng_f1={obs.freq1}, teng_f2={obs.freq2}, f0={obs.bw}, gain1={beam_gain}, gain2={beam_gain})"
         d.update({ts:cmd})
 
         ts += (recording_buffer)/24/3600

--- a/observing/schedule.py
+++ b/observing/schedule.py
@@ -40,6 +40,20 @@ def put_sched(sched=None):
     ls.put_dict('/mon/observing/schedule', sched_dict)
 
 
+def put_dict(filename):
+    """ Parses SDF and puts dict in etcd for later retrieval by data recorders
+    """
+
+    dd = sdf_to_dict(filename)
+    session_mode_name = f'{dd['SESSION']['SESSION_ID']}_{dd['SESSION']['SESSION_MODE']}'
+    if 'SESSION_DRX_BEAM' in dd['SESSION']:
+        session_mode_name += dd['SESSION']['SESSION_DRX_BEAM']
+
+    dd0 = ls.get_dict('/mon/observing/sdfdict')
+    dd0.update({session_mode_name: dd})
+    ls.put_dict('/mon/observing/sdfdict', dd0)
+
+                
 def put_submitted(rows):
     """ Takes submitted rows and sets values in etcd
     """

--- a/observing/schedule.py
+++ b/observing/schedule.py
@@ -3,7 +3,7 @@ from pandas import concat, DataFrame
 from astropy import time
 import logging
 from dsautils import dsa_store
-from observing import obsstate
+from observing import obsstate, parsesdf
 
 logger = logging.getLogger('observing')
 ls = dsa_store.DsaStore()
@@ -44,12 +44,14 @@ def put_dict(filename):
     """ Parses SDF and puts dict in etcd for later retrieval by data recorders
     """
 
-    dd = sdf_to_dict(filename)
-    session_mode_name = f'{dd['SESSION']['SESSION_ID']}_{dd['SESSION']['SESSION_MODE']}'
+    dd = parsesdf.sdf_to_dict(filename)
+    session_mode_name = f"{dd['SESSION']['SESSION_ID']}_{dd['SESSION']['SESSION_MODE']}"
     if 'SESSION_DRX_BEAM' in dd['SESSION']:
         session_mode_name += dd['SESSION']['SESSION_DRX_BEAM']
 
     dd0 = ls.get_dict('/mon/observing/sdfdict')
+    if dd0 is None:
+        dd0 = {}
     dd0.update({session_mode_name: dd})
     ls.put_dict('/mon/observing/sdfdict', dd0)
 

--- a/scripts/executor.py
+++ b/scripts/executor.py
@@ -72,6 +72,10 @@ if __name__ == "__main__":
                             logger.warning("Could not add session to obsstate.")
 
                         sched0 = schedule.sched_update([sched0, sched], mode=mode)
+
+                        # make function to parse and add dictionary there, keyed by session_id
+                        schedule.put_dict(filename)
+
                     else:
                         # should probably log this better or return to cli user
                         logger.warning(f"Session {filename} conflicts with existing session.")


### PR DESCRIPTION
This will use a new key in etcd to store a dictionary represenation of each SDF submitted. They can be retrieved later by the unique ID for a given SDF that is parsed successfully.