### PR TITLE
Creating AZALT observing mode and SDF submission logging improvement

### DIFF
--- a/observing/classes.py
+++ b/observing/classes.py
@@ -13,7 +13,6 @@ class EphemModes(Enum):
     trk_lun = 'TRK_LUN'
     trk_radec = 'TRK_RADEC'
     azalt = "AZALT"
-    stepped = "STEPPED"
 
 class Session:
     """
@@ -99,7 +98,7 @@ class Observation:
         # Setting ra and dec values if the system isn't using one of the modes that require ephemerides: 
         ephem_modes = tracking_modes[1:]
         
-        if self.obs_mode not in ephem_modes+['STEPPED', 'AZALT']:
+        if self.obs_mode not in ephem_modes+['AZALT']:
             # If the dec is None, then assume that the user wants to resolve to a target based on its name
             if dec is None and self.obs_mode:
                 assert(obj_name is not None)
@@ -114,7 +113,7 @@ class Observation:
                 self.az = None
                 self.alt = None
                 self.obj_name = obj_name
-        elif self.obs_mode in ['STEPPED', 'AZALT']:
+        elif self.obs_mode in ['AZALT']:
             self.az = float(az)
             self.alt = float(alt)
             self.ra = None

--- a/observing/cli.py
+++ b/observing/cli.py
@@ -45,9 +45,11 @@ def submit_sdf(sdffile, asap, reset):
 
         sched = parsesdf.make_sched(sdffile)
         if schedule.is_conflicted(sched):
-            raise RuntimeError(f"Warning: SDF {sdffile} is conflicted with current schedule")
+            print(f"Warning: SDF {sdffile} is conflicted with current schedule")
+            return
     except:
-        raise RuntimeError(f"Warning: SDF {sdffile} could not be parsed into scheduling commands.")
+        print(f"Warning: SDF {sdffile} could not be parsed into scheduling commands.")
+        return
 
     if reset:
         ls.put_dict('/mon/observing/schedule', {})
@@ -62,6 +64,7 @@ def submit_sdf(sdffile, asap, reset):
     sdfdict = ls.get_dict('/mon/observing/sdfdict')
     if session_mode_name not in sdfdict:
         print(f"SDF failed to get parsed by scheduler (session mode name: {session_mode_name}")
+        return
 
     scheduled = ls.get_dict('/mon/observing/schedule')
     active = ls.get_dict('/mon/observing/submitted')

--- a/observing/cli.py
+++ b/observing/cli.py
@@ -42,6 +42,8 @@ def submit_sdf(sdffile, asap, reset):
         session_mode_name = f"{dd['SESSION']['SESSION_ID']}_{dd['SESSION']['SESSION_MODE']}"
         if 'SESSION_DRX_BEAM' in dd['SESSION']:
             session_mode_name += dd['SESSION']['SESSION_DRX_BEAM']
+        if session_mode name in ls.get_dict('/mon/observing/sdfdict'):
+            print(f"Warning: SDF {sdffile} was parsed by scheduler before. Was this SDF already submitted?")
 
         sched = parsesdf.make_sched(sdffile)
         if schedule.is_conflicted(sched) and not asap:
@@ -63,7 +65,7 @@ def submit_sdf(sdffile, asap, reset):
     sleep(0.5)
     sdfdict = ls.get_dict('/mon/observing/sdfdict')
     if session_mode_name not in sdfdict:
-        print(f"SDF failed to get parsed by scheduler (session mode name: {session_mode_name}")
+        print(f"SDF failed to get parsed by scheduler (session mode name: {session_mode_name})")
         return
 
     scheduled = ls.get_dict('/mon/observing/schedule')

--- a/observing/cli.py
+++ b/observing/cli.py
@@ -44,7 +44,7 @@ def submit_sdf(sdffile, asap, reset):
             session_mode_name += dd['SESSION']['SESSION_DRX_BEAM']
 
         sched = parsesdf.make_sched(sdffile)
-        if schedule.is_conflicted(sched):
+        if schedule.is_conflicted(sched) and not asap:
             print(f"Warning: SDF {sdffile} is conflicted with current schedule")
             return
     except:

--- a/observing/cli.py
+++ b/observing/cli.py
@@ -52,14 +52,17 @@ def submit_sdf(sdffile, asap, reset):
     mode = 'asap' if asap else 'buffer'
     ls.put_dict('/cmd/observing/submitsdf', {'filename': sdffile, 'mode': mode})
 
-    sleep(0.1)
+    sleep(0.5)
     sdfdict = ls.get_dict('/mon/observing/sdfdict')
-    assert session_mode_name in sdfdict, f"Session {session_mode_name} not found in sdfdict"
+    if session_mode_name not in sdfdict:
+        print(f"Session {session_mode_name} not found in sdfdict")
+
     scheduled = ls.get_dict('/mon/observing/schedule')
     active = ls.get_dict('/mon/observing/submitted')
     any_scheduled = any([key for key in scheduled if session_mode_name in scheduled[key]])
     any_active = any([key for key in active if session_mode_name in active[key]])
-    assert any_scheduled or any_active, f"Session {session_mode_name} not scheduled or actively observing"
+    if not any_scheduled and not any_active:
+        print(f"Session {session_mode_name} not scheduled or actively observing")
 
     print("Successfullly submitted SDF.")
 

--- a/observing/cli.py
+++ b/observing/cli.py
@@ -42,7 +42,7 @@ def submit_sdf(sdffile, asap, reset):
         session_mode_name = f"{dd['SESSION']['SESSION_ID']}_{dd['SESSION']['SESSION_MODE']}"
         if 'SESSION_DRX_BEAM' in dd['SESSION']:
             session_mode_name += dd['SESSION']['SESSION_DRX_BEAM']
-        if session_mode name in ls.get_dict('/mon/observing/sdfdict'):
+        if session_mode_name in ls.get_dict('/mon/observing/sdfdict'):
             print(f"Warning: SDF {sdffile} was parsed by scheduler before. Was this SDF already submitted?")
 
         sched = parsesdf.make_sched(sdffile)

--- a/observing/makesdf.py
+++ b/observing/makesdf.py
@@ -104,7 +104,7 @@ def make_oneobs(obs_count, sess_mode=None, obs_mode=None, obs_start=None, obs_du
             obj_name = 'Jupiter'
         ra = 0.
         dec = 0.
-    elif obs_mode in ['STEPPED', 'AZALT']:
+    elif obs_mode in ['AZALT']:
         logger.info("Using provided (RA, Dec) as (Az, Alt) for this obs_mode.")
         obs_mode = classes.EphemModes(obs_mode)
         az = ra
@@ -219,9 +219,9 @@ def make_obs_block(obs_id, start_time:str, duration, ra = None, dec = None, obj_
         lines += f"OBS_DEC         %+.9f\n" % (dec)
 
     if az is not None:
-        lines += f"OBS_STP_C1[1]   {az}\n"
+        lines += f"OBS_AZ          {az}\n"
     if alt is not None:
-        lines += f"OBS_STP_C2[1]   {alt}\n"
+        lines += f"OBS_ALT         {alt}\n"
 
     lines += "OBS_FREQ1       1161394218\n"
     lines += "OBS_FREQ1+      53.000000009 MHz\n"

--- a/observing/parsesdf.py
+++ b/observing/parsesdf.py
@@ -143,8 +143,8 @@ def make_obs_list(inp:dict):
             if ra is not None:
                 ra = float(ra) * 15    # hours -> degrees
             dec = inp['OBSERVATIONS'][i].get('OBS_DEC', None)
-            az = inp['OBSERVATIONS'][i].get('OBS_STP_C1[1]', None)
-            alt = inp['OBSERVATIONS'][i].get('OBS_STP_C2[1]', None)
+            az = inp['OBSERVATIONS'][i].get('OBS_AZ', None)
+            alt = inp['OBSERVATIONS'][i].get('OBS_ALT', None)
             int_time = inp['OBSERVATIONS'][i].get('OBS_INT_TIME', None)
             obj_name = inp['OBSERVATIONS'][i].get('OBS_TARGET', None)
             if obj_name is None and ra is None and dec is None and az is None and alt is None:
@@ -157,14 +157,10 @@ def make_obs_list(inp:dict):
                         bw = int(bw)
 
                     freq1 = inp['OBSERVATIONS'][i].get('OBS_FREQ1', None)
-                    if freq1 is None:
-                        freq1 = inp['OBSERVATIONS'][i].get('OBS_STP_FREQ1[1]', None)
                     if freq1 is not None:
                         freq1 = int(freq1)
 
                     freq2 = inp['OBSERVATIONS'][i].get('OBS_FREQ2', None)
-                    if freq2 is None:
-                        freq2 = inp['OBSERVATIONS'][i].get('OBS_STP_FREQ2[1]', None)
                     if freq2 is not None:
                         freq2 = int(freq2)
 

--- a/observing/parsesdf.py
+++ b/observing/parsesdf.py
@@ -168,8 +168,7 @@ def make_obs_list(inp:dict):
                     if gain is not None:
                         gain = int(gain)
                 except:
-                    # There is a STEPPED mode that allows a sequence of OBS_STP_* keywords.  That doesn't look
-                    # to be supported currently.
+                    # Not yet supporting STEPPED mode (OBS_STP_* keywords)
                     raise Exception('voltage observation requires defining OBS_BW, OBS_FREQ1, and OBS_FREQ2')
             else:
                 bw, freq1, freq2, gain = None, None, None, None


### PR DESCRIPTION
- Removing support for STEPPED
- Adding a new OBS_MODE of AZALT (not backwards compatible with `lsl`)
- CLI `submit-sdf` subcommand will parse SDF and test for multiple ways that scheduling can fail within the scheduler.
- CLI prints more helpful messages if we expect scheduler to fail to run SDF (also a "successful" message).