### PR TITLE
feature: use do_cal to force apply calibration

### DIFF
--- a/observing/classes.py
+++ b/observing/classes.py
@@ -18,7 +18,7 @@ class Session:
     """
     Contains information about the controller settings for the session 
     """
-    def __init__(self, obs_type, session_id, config_file = None, cal_directory = None, do_cal = True,beam_num = None):
+    def __init__(self, obs_type, session_id, config_file = None, cal_directory = None, do_cal = False, beam_num = None):
         """
         
         :param obs_type: defines whether the session will be for a power beam, voltage beam, or slow/fast vis

--- a/observing/cli.py
+++ b/observing/cli.py
@@ -79,17 +79,22 @@ def submit_sdf(sdffile, asap, reset):
 
 @cli.command()
 @click.argument('sdffile')
-@click.option('--n-obs', default=1, type=int, help='Number of observations to create. Each obs may only have different target/ra/dec/time.')
+@click.option('--n-obs', default=1, type=int,
+              help='Number of observations to create. Each obs may only have different target/ra/dec/time.')
 @click.option('--sess-mode', default='POWER', type=str, help='Session mode (FAST, SLOW, POWER, VOLT)')
 @click.option('--beam-num', default=None, type=int, help='POWER/VOLT beam number')
-@click.option('--obs-mode', default='TRK_RADEC', type=str, help='Observation mode (e.g. TRK_RADEC, AZALT, TRK_JUPITER, TRK_SOLAR, TRK_LUNAR)')
+@click.option('--cal-dir', default='/home/pipeline/caltables/latest', type=str,
+              help='Calibration directory with tables to apply if not already calibrated.')
+@click.option('--do-cal', is_flag=True, default=False, show_default=True, help='Force the application of calibration')
+@click.option('--obs-mode', default='TRK_RADEC', type=str,
+              help='Observation mode (e.g. TRK_RADEC, AZALT, TRK_JUPITER, TRK_SOLAR, TRK_LUNAR)')
 @click.option('--obs-start', default=None, help='Observation start time (UTC) in YYYY-MM-DDTHH:MM:SS format or "now"')
 @click.option('--obs-dur', default=None, type=int, help='Observation duration in milliseconds')
 @click.option('--ra', default=None, type=float, help='RA of target (in hours). Interpreted as Azimuth for AZALT obs-mode.')
 @click.option('--dec', default=None, type=float, help='Dec of target (in degrees). Interpreted as Azimuth for AZALT obs-mode.')
 @click.option('--obj-name', default=None, type=str, help='Name of object to track (used as alternative to RA/Dec)')
 @click.option('--int-time', default=None, type=int, help='Integration time in milliseconds')
-def create_sdf(sdffile, n_obs, sess_mode, beam_num, obs_mode, obs_start, obs_dur, ra, dec, obj_name, int_time):
+def create_sdf(sdffile, n_obs, sess_mode, beam_num, cal_dir, do_cal, obs_mode, obs_start, obs_dur, ra, dec, obj_name, int_time):
     """ Create an SDF file.
     """
 

--- a/observing/makesdf.py
+++ b/observing/makesdf.py
@@ -12,9 +12,9 @@ import getpass
 logger = logging.getLogger('observing')
 
 
-def create(out_name, sess_id=None, sess_mode=None, beam_num=None, cal_dir='/home/pipeline/caltables/latest', pi_id=None,
-           pi_name=None, config_file=None, n_obs=1, obs_mode=None, obs_start=None, obs_dur=None, ra=None, dec=None,
-           obj_name=None, int_time=None):
+def create(out_name, sess_id=None, sess_mode=None, beam_num=None, cal_dir='/home/pipeline/caltables/latest', do_cal=False,
+           pi_id=None, pi_name=None, config_file=None, n_obs=1, obs_mode=None, obs_start=None, obs_dur=None, ra=None,
+           dec=None, obj_name=None, int_time=None):
     """ Create a file out_name as an SDF
     """
 
@@ -38,9 +38,12 @@ def create(out_name, sess_id=None, sess_mode=None, beam_num=None, cal_dir='/home
             beam_num = int(inp)
         if cal_dir is not None:
             assert os.path.exists(cal_dir), f"cal_dir ({cal_dir}) does not exist"
+        if do_cal:
+            assert os.path.exists(cal_dir), f"Cannot use do_cal if cal_dir ({cal_dir}) does not exist"
     else:
         beam_num = None
         cal_dir = None
+        do_cal = False
 
     if pi_name is None:
         pi_name = getpass.getuser()
@@ -58,7 +61,7 @@ def create(out_name, sess_id=None, sess_mode=None, beam_num=None, cal_dir='/home
         config_file = "/home/pipeline/proj/lwa-shell/mnc_python/config/lwa_config_calim.yaml"
 
     try:
-        session_preamble = make_session_preamble(sess_id, sess_mode, pi_id, pi_name, beam_num, config_file, cal_dir)
+        session_preamble = make_session_preamble(sess_id, sess_mode, pi_id, pi_name, beam_num, config_file, cal_dir, do_cal)
         sdf_text += session_preamble
         print(session_preamble)
     except:
@@ -165,7 +168,8 @@ def make_oneobs(obs_count, sess_mode=None, obs_mode=None, obs_start=None, obs_du
 
 
 def make_session_preamble(session_id, session_mode, pi_id = 0, pi_name:str = 'Observer', beam_num = None,
-                          config_dir = '/home/pipeline/proj/lwa-shell/mnc_python/config/lwa_calim_config.yaml', cal_dir = None):
+                          config_dir = '/home/pipeline/proj/lwa-shell/mnc_python/config/lwa_calim_config.yaml', cal_dir = None,
+                          do_cal = False):
     """ Create preamble info required for a proper SDF
     """
 
@@ -179,6 +183,7 @@ def make_session_preamble(session_id, session_mode, pi_id = 0, pi_name:str = 'Ob
     lines += f'CONFIG_FILE      {config_dir}\n'
     if cal_dir != None:
         lines += f'CAL_DIR          {cal_dir}\n'
+    lines += f'DO_CAL           {do_cal}\n'
     lines += '\n'
 
     return lines


### PR DESCRIPTION
cal_dir, if set to a string path with tables, will now be used only to apply cal, if not already calibrated. if neither, then existing calibration state will be used.
also adding both to cli for `create-sdf`.