### PR TITLE
using obs_mode VOLTRAW to record with "raw_record" command on drt1

### DIFF
--- a/observing/__init__.py
+++ b/observing/__init__.py
@@ -1,4 +1,4 @@
-__all__ = ['parsesdf', 'classes', 'makesdf']
+__all__ = ['parsesdf', 'makesdf']
 
 from observing import *
 

--- a/observing/classes.py
+++ b/observing/classes.py
@@ -3,6 +3,7 @@ import os.path
 
 class ObsType(Enum):
     volt = 'VOLT'
+    voltraw = 'VOLTRAW'
     power = 'POWER'
     fast = 'FAST'
     slow = 'SLOW'
@@ -58,7 +59,7 @@ class Session:
         if self.obs_type is ObsType.power and self.beam_num not in valid_power_beam_nums:
             raise Exception("You must specify a valid beam number if you want to observe with a beam")
         valid_volt_beam_nums = range(1,2)
-        if self.obs_type is ObsType.volt and self.beam_num not in valid_volt_beam_nums:
+        if self.obs_type in [ObsType.volt, ObsType.voltraw] and self.beam_num not in valid_volt_beam_nums:
             raise Exception("You must specify a valid beam number if you want to observe with a beam")
         return
 
@@ -133,7 +134,7 @@ class Observation:
 
         assert self.int_time <= 1024, "Integration time must be less than 1024 ms"
             
-        if self.session.obs_type is ObsType.volt:
+        if self.session.obs_type is ObsType.volt or self.session.obs_type is ObsType.voltraw:
             self.bw = bw
             self.freq1 = freq1
             self.freq2 = freq2

--- a/observing/parsesdf.py
+++ b/observing/parsesdf.py
@@ -199,7 +199,8 @@ def fast_vis_obs(obs_list, session, mode="buffer"):
     cmd = f"from mnc import control"
     d = {ts:cmd}
 
-    ts += 1/(24*3600)
+
+    ts += 3/(24*3600)
     cmd = f"con = control.Controller('{session.config_file}')"
     d.update({ts:cmd})
 
@@ -239,7 +240,7 @@ def slow_vis_obs(obs_list, session, mode="buffer"):
     cmd = f"from mnc import control"
     d = {ts:cmd}
 
-    ts += 1/(24*3600)
+    ts += 3/(24*3600)
     cmd = f"con = control.Controller('{session.config_file}')"
     d.update({ts:cmd})
 
@@ -302,7 +303,7 @@ def power_beam_obs(obs_list, session, mode='buffer'):
     cmd = f"from mnc import control"
     d = {ts:cmd}
 
-    ts += 1/(24*3600)
+    ts += 3/(24*3600)
     cmd = f"con = control.Controller('{session.config_file}')"
     d.update({ts:cmd})
     # okay. originally, I was trying to avoid having two commands have the same timestamp to avoid confusing 
@@ -324,8 +325,9 @@ def power_beam_obs(obs_list, session, mode='buffer'):
         ts += cal_buffer/(24*3600)
 
     # Go through the list of observations
+#    ts += configure_buffer/(24*3600)
     for obs in obs_list:
-        ts += configure_buffer/(24*3600)  # obs.obs_start - (pointing_buffer + recording_buffer)/(24*3600)
+        ts = obs.obs_start - (pointing_buffer + recording_buffer)/(24*3600)
         if mode == 'buffer':
             t0 = obs.obs_start
         elif mode == 'asap':
@@ -336,11 +338,11 @@ def power_beam_obs(obs_list, session, mode='buffer'):
         ts += recording_buffer/(24*3600)
         if obs.ra is None and obs.dec is None and obs.az is None and obs.alt is None:
             targetname = obs.obj_name
-            cmd = f"con.control_bf(num = {session.beam_num}, targetname='{targetname}', track={obs.tracking}, duration={(obs.obs_dur+pointing_buffer)/1e3})"
+            cmd = f"con.control_bf(num = {session.beam_num}, targetname='{targetname}', track={obs.tracking}, duration={(obs.obs_dur/1e3)+pointing_buffer})"
         elif obs.ra is not None and obs.dec is not None:
-            cmd = f"con.control_bf(num = {session.beam_num}, coord = ({obs.ra/15},{obs.dec}), track={obs.tracking}, duration={(obs.obs_dur+pointing_buffer)/1e3})"
+            cmd = f"con.control_bf(num = {session.beam_num}, coord = ({obs.ra/15},{obs.dec}), track={obs.tracking}, duration={(obs.obs_dur/1e3)+pointing_buffer})"
         elif obs.az is not None and obs.alt is not None:
-            cmd = f"con.control_bf(num = {session.beam_num}, coord = ({obs.az},{obs.alt}), coordtype='azel', track=False, duration={(obs.obs_dur+pointing_buffer)/1e3})"
+            cmd = f"con.control_bf(num = {session.beam_num}, coord = ({obs.az},{obs.alt}), coordtype='azel', track=False, duration={(obs.obs_dur)/1e3+pointing_buffer})"
             
         d.update({ts:cmd})
 
@@ -395,7 +397,7 @@ def volt_beam_obs(obs_list, session, mode='buffer'):
     cmd = f"from mnc import control"
     d = {ts:cmd}
 
-    ts += 1/(24*3600)
+    ts += 3/(24*3600)
     cmd = f"con = control.Controller('{session.config_file}')"
     d.update({ts:cmd})
     # okay. originally, I was trying to avoid having two commands have the same timestamp to avoid confusing 
@@ -405,7 +407,7 @@ def volt_beam_obs(obs_list, session, mode='buffer'):
 
     if calibratebeams or session.do_cal == True:
         # re-assign calibration directory if it is specified
-        ts += 1/(24*3600)
+        ts += 3/(24*3600)
         cmd = f"con.conf['xengines']['cal_directory'] = '{session.cal_directory}'"
         d.update({ts:cmd})
 

--- a/observing/parsesdf.py
+++ b/observing/parsesdf.py
@@ -391,7 +391,9 @@ def volt_beam_obs(obs_list, session, mode='buffer'):
 
     if 'raw' in session.obs_type.value.lower():
         command_suffix = "raw"
-    
+    else:
+        command_suffix = ""
+
     t0 = obs_list[0].obs_start
     ts = t0 - dt
     cmd = f"from mnc import control"

--- a/observing/parsesdf.py
+++ b/observing/parsesdf.py
@@ -307,7 +307,6 @@ def power_beam_obs(obs_list, session, mode='buffer'):
     d.update({ts:cmd})
     # okay. originally, I was trying to avoid having two commands have the same timestamp to avoid confusing 
     # the scheduler. I'm deciding that should not be the perogative of the parser.
-    print(d)
     calibratebeams = session.cal_directory is not None and session.do_cal
 
     if calibratebeams or session.do_cal:
@@ -321,7 +320,6 @@ def power_beam_obs(obs_list, session, mode='buffer'):
     # always calibrate uncalibrated beams if dir provided. Give user option to apply even if already calibrated.
     cmd = f"con.configure_xengine(['dr'+str({session.beam_num})], calibratebeams = {calibratebeams}, force={session.do_cal})"
     d.update({ts:cmd})
-    print(d)
     if calibratebeams or session.do_cal == True:
         ts += cal_buffer/(24*3600)
 
@@ -334,7 +332,7 @@ def power_beam_obs(obs_list, session, mode='buffer'):
             t0 = "'now'"
         cmd = f"con.start_dr(recorders=['dr'+str({session.beam_num})], duration = {obs.obs_dur}, time_avg={obs.int_time}, t0 = {t0})"
         d.update({ts:cmd})
-        print(d)
+
         ts += recording_buffer/(24*3600)
         if obs.ra is None and obs.dec is None and obs.az is None and obs.alt is None:
             targetname = obs.obj_name

--- a/observing/parsesdf.py
+++ b/observing/parsesdf.py
@@ -199,7 +199,7 @@ def fast_vis_obs(obs_list, session, mode="buffer"):
     cmd = f"from mnc import control"
     d = {ts:cmd}
 
-    ts += 1/(24*3600)
+    ts += 3/(24*3600)
     cmd = f"con = control.Controller('{session.config_file}')"
     d.update({ts:cmd})
 
@@ -239,7 +239,7 @@ def slow_vis_obs(obs_list, session, mode="buffer"):
     cmd = f"from mnc import control"
     d = {ts:cmd}
 
-    ts += 1/(24*3600)
+    ts += 3/(24*3600)
     cmd = f"con = control.Controller('{session.config_file}')"
     d.update({ts:cmd})
 
@@ -302,7 +302,7 @@ def power_beam_obs(obs_list, session, mode='buffer'):
     cmd = f"from mnc import control"
     d = {ts:cmd}
 
-    ts += 1/(24*3600)
+    ts += 3/(24*3600)
     cmd = f"con = control.Controller('{session.config_file}')"
     d.update({ts:cmd})
     # okay. originally, I was trying to avoid having two commands have the same timestamp to avoid confusing 
@@ -392,7 +392,7 @@ def volt_beam_obs(obs_list, session, mode='buffer'):
     cmd = f"from mnc import control"
     d = {ts:cmd}
 
-    ts += 1/(24*3600)
+    ts += 3/(24*3600)
     cmd = f"con = control.Controller('{session.config_file}')"
     d.update({ts:cmd})
     # okay. originally, I was trying to avoid having two commands have the same timestamp to avoid confusing 
@@ -402,7 +402,7 @@ def volt_beam_obs(obs_list, session, mode='buffer'):
 
     if calibratebeams or session.do_cal == True:
         # re-assign calibration directory if it is specified
-        ts += 1/(24*3600)
+        ts += 3/(24*3600)
         cmd = f"con.conf['xengines']['cal_directory'] = '{session.cal_directory}'"
         d.update({ts:cmd})
 

--- a/observing/parsesdf.py
+++ b/observing/parsesdf.py
@@ -199,7 +199,7 @@ def fast_vis_obs(obs_list, session, mode="buffer"):
     cmd = f"from mnc import control"
     d = {ts:cmd}
 
-    ts += 0.1/(24*3600)
+    ts += 1/(24*3600)
     cmd = f"con = control.Controller('{session.config_file}')"
     d.update({ts:cmd})
 
@@ -208,7 +208,7 @@ def fast_vis_obs(obs_list, session, mode="buffer"):
     if session.beam_num is not None:
         session_mode_name += f"{session.beam_num}"
 
-    ts += 0.1/(24*3600)
+    ts += 1/(24*3600)
     cmd = "con.configure_xengine(['drvf'])"
     d.update({ts:cmd})
 
@@ -239,7 +239,7 @@ def slow_vis_obs(obs_list, session, mode="buffer"):
     cmd = f"from mnc import control"
     d = {ts:cmd}
 
-    ts += 0.1/(24*3600)
+    ts += 1/(24*3600)
     cmd = f"con = control.Controller('{session.config_file}')"
     d.update({ts:cmd})
 
@@ -248,7 +248,7 @@ def slow_vis_obs(obs_list, session, mode="buffer"):
     if session.beam_num is not None:
         session_mode_name += f"{session.beam_num}"
 
-    ts += 0.1/(24*3600)
+    ts += 1/(24*3600)
     cmd = "con.configure_xengine(['drvs'])"
     d.update({ts:cmd})
 
@@ -276,11 +276,11 @@ def power_beam_obs(obs_list, session, mode='buffer'):
         pointing_buffer = 10
         recording_buffer = 5
     elif mode == 'asap':
-        controller_buffer = 0.1
-        configure_buffer = 0.1
-        cal_buffer = 0.1
-        pointing_buffer = 0.1
-        recording_buffer = 0.1
+        controller_buffer = 1
+        configure_buffer = 1
+        cal_buffer = 1
+        pointing_buffer = 1
+        recording_buffer = 1
 
     calibratebeams = session.cal_directory is not None and session.do_cal
 
@@ -302,40 +302,40 @@ def power_beam_obs(obs_list, session, mode='buffer'):
     cmd = f"from mnc import control"
     d = {ts:cmd}
 
-    ts += 0.1/(24*3600)
+    ts += 1/(24*3600)
     cmd = f"con = control.Controller('{session.config_file}')"
     d.update({ts:cmd})
     # okay. originally, I was trying to avoid having two commands have the same timestamp to avoid confusing 
     # the scheduler. I'm deciding that should not be the perogative of the parser.
-        
+    print(d)
     calibratebeams = session.cal_directory is not None and session.do_cal
 
     if calibratebeams or session.do_cal:
         # re-assign calibration directory if it is specified
-        ts += 0.1/(24*3600)
+        ts += 1/(24*3600)
         cmd = f"con.conf['xengines']['cal_directory'] = '{session.cal_directory}'"
         d.update({ts:cmd})
 
     # Configure for the beam
-    ts += controller_buffer/24/3600
+    ts += controller_buffer/(24*3600)
     # always calibrate uncalibrated beams if dir provided. Give user option to apply even if already calibrated.
     cmd = f"con.configure_xengine(['dr'+str({session.beam_num})], calibratebeams = {calibratebeams}, force={session.do_cal})"
     d.update({ts:cmd})
-
+    print(d)
     if calibratebeams or session.do_cal == True:
-        ts += cal_buffer/24/3600
+        ts += cal_buffer/(24*3600)
 
     # Go through the list of observations
     for obs in obs_list:
-        ts = obs.obs_start - (pointing_buffer + recording_buffer)/24/3600
+        ts += configure_buffer/(24*3600)  # obs.obs_start - (pointing_buffer + recording_buffer)/(24*3600)
         if mode == 'buffer':
             t0 = obs.obs_start
         elif mode == 'asap':
             t0 = "'now'"
         cmd = f"con.start_dr(recorders=['dr'+str({session.beam_num})], duration = {obs.obs_dur}, time_avg={obs.int_time}, t0 = {t0})"
         d.update({ts:cmd})
-
-        ts += recording_buffer/24/3600
+        print(d)
+        ts += recording_buffer/(24*3600)
         if obs.ra is None and obs.dec is None and obs.az is None and obs.alt is None:
             targetname = obs.obj_name
             cmd = f"con.control_bf(num = {session.beam_num}, targetname='{targetname}', track={obs.tracking}, duration={(obs.obs_dur+pointing_buffer)/1e3})"
@@ -346,7 +346,7 @@ def power_beam_obs(obs_list, session, mode='buffer'):
             
         d.update({ts:cmd})
 
-    ts += obs.obs_dur/1e3/24/3600
+    ts += obs.obs_dur/1e3/(24*3600)
     cmd = "print('Observation complete')"
     d.update({ts:cmd})
 
@@ -368,11 +368,11 @@ def volt_beam_obs(obs_list, session, mode='buffer'):
         pointing_buffer = 10
         recording_buffer = 5
     elif mode == 'asap':
-        controller_buffer = 0.1
-        configure_buffer = 0.1
-        cal_buffer = 0.1
-        pointing_buffer = 0.1
-        recording_buffer = 0.1
+        controller_buffer = 1
+        configure_buffer = 1
+        cal_buffer = 1
+        pointing_buffer = 1
+        recording_buffer = 1
 
     calibratebeams = session.cal_directory is not None and session.do_cal
 
@@ -397,7 +397,7 @@ def volt_beam_obs(obs_list, session, mode='buffer'):
     cmd = f"from mnc import control"
     d = {ts:cmd}
 
-    ts += 0.1/(24*3600)
+    ts += 1/(24*3600)
     cmd = f"con = control.Controller('{session.config_file}')"
     d.update({ts:cmd})
     # okay. originally, I was trying to avoid having two commands have the same timestamp to avoid confusing 
@@ -407,19 +407,19 @@ def volt_beam_obs(obs_list, session, mode='buffer'):
 
     if calibratebeams or session.do_cal == True:
         # re-assign calibration directory if it is specified
-        ts += 0.1/(24*3600)
+        ts += 1/(24*3600)
         cmd = f"con.conf['xengines']['cal_directory'] = '{session.cal_directory}'"
         d.update({ts:cmd})
 
     # Configure for the beam
-    ts += controller_buffer/24/3600 
+    ts += controller_buffer/(24*3600 )
     cmd = f"con.configure_xengine(['dr'+str({session.beam_num})], calibratebeams = {calibratebeams}, force={session.do_cal})"
     d.update({ts:cmd})
-    ts += (configure_buffer + cal_buffer)/24/3600
+    ts += (configure_buffer + cal_buffer)/(24*3600)
 
     # Go through the list of observations
     for obs in obs_list:
-        ts = obs.obs_start - (pointing_buffer + recording_buffer)/24/3600
+        ts = obs.obs_start - (pointing_buffer + recording_buffer)/(24*3600)
         if mode == 'buffer':
             t0 = obs.obs_start
         elif mode == 'asap':
@@ -437,7 +437,7 @@ def volt_beam_obs(obs_list, session, mode='buffer'):
         cmd = f"con.start_dr(recorders=['drt'+str({session.beam_num}{command_suffix})], duration = {obs.obs_dur}, time_avg=0, t0={t0}, teng_f1={obs.freq1}*(196e6/2**32), teng_f2={obs.freq2}*(196e6/2**32), f0={obs.bw}, gain1={beam_gain1}, gain2={beam_gain2})"
         d.update({ts:cmd})
 
-        ts += (recording_buffer)/24/3600
+        ts += (recording_buffer)/(24*3600)
         if obs.ra is None and obs.dec is None and obs.az is None and obs.alt is None:
             targetname = obs.obj_name
             cmd = f"con.control_bf(num = {session.beam_num}, targetname='{targetname}', track={obs.tracking}, duration={(obs.obs_dur+pointing_buffer)/1e3})"
@@ -448,7 +448,7 @@ def volt_beam_obs(obs_list, session, mode='buffer'):
 
         d.update({ts:cmd})
 
-    ts += obs.obs_dur/1e3/24/3600
+    ts += obs.obs_dur/1e3/(24*3600)
     cmd = "print('Observation complete')"
     d.update({ts:cmd})
     


### PR DESCRIPTION
The observing modes had assumed that they mapped directly to recorder names. The "raw_record" command goes to the `drt1` recorder, so we need to add some extra logic to map the SDF to the action.